### PR TITLE
small doc typo and a fix to make kernel PCA return correct dims

### DIFF
--- a/R/kpca.R
+++ b/R/kpca.R
@@ -72,7 +72,7 @@ kPCA <- setClass(
             appl.meta <- if (inherits(x, "dimRedData")) x@meta else data.frame()
             proj <- if (inherits(x, "dimRedData")) x@data else x
 
-            proj <- kernlab::predict(res, proj)
+            proj <- kernlab::predict(res, proj)[, 1:pars$ndim, drop = FALSE]
             colnames(proj) <- paste0("kPCA", 1:ncol(proj))
 
             new("dimRedData", data = proj, meta = appl.meta)

--- a/man-roxygen/dimRedMethodSlots.R
+++ b/man-roxygen/dimRedMethodSlots.R
@@ -1,3 +1,3 @@
 #' @slot fun A function that does the embedding and returns a
 #'     dimRedResult object.
-#' @slot stdpars The standard parameters for the funciton.
+#' @slot stdpars The standard parameters for the function.

--- a/man/DRR-class.Rd
+++ b/man/DRR-class.Rd
@@ -17,7 +17,7 @@ DRR is a non-linear extension of PCA that uses Kernel Ridge regression.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/DiffusionMaps-class.Rd
+++ b/man/DiffusionMaps-class.Rd
@@ -18,7 +18,7 @@ approximate a manifold.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/DrL-class.Rd
+++ b/man/DrL-class.Rd
@@ -18,7 +18,7 @@ embedding which uses several steps.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/FastICA-class.Rd
+++ b/man/FastICA-class.Rd
@@ -19,7 +19,7 @@ a linear Projection.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/FruchtermanReingold-class.Rd
+++ b/man/FruchtermanReingold-class.Rd
@@ -15,7 +15,7 @@ algorithm.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/HLLE-class.Rd
+++ b/man/HLLE-class.Rd
@@ -18,7 +18,7 @@ extension to non-convex subsets in lowdimensional space.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/Isomap-class.Rd
+++ b/man/Isomap-class.Rd
@@ -19,7 +19,7 @@ performed on the resulting distance matrix.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/KamadaKawai-class.Rd
+++ b/man/KamadaKawai-class.Rd
@@ -23,7 +23,7 @@ repelling forces.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/LLE-class.Rd
+++ b/man/LLE-class.Rd
@@ -19,7 +19,7 @@ manifold and in highdimensional space.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/LaplacianEigenmaps-class.Rd
+++ b/man/LaplacianEigenmaps-class.Rd
@@ -18,7 +18,7 @@ separate non-convex clusters under the name spectral clustering.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/MDS-class.Rd
+++ b/man/MDS-class.Rd
@@ -19,7 +19,7 @@ be used, but it is computationally more demanding.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/PCA-class.Rd
+++ b/man/PCA-class.Rd
@@ -23,7 +23,7 @@ probably always be applied as a baseline if other methods are tested.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/kPCA-class.Rd
+++ b/man/kPCA-class.Rd
@@ -17,7 +17,7 @@ Kernel PCA is a nonlinear extension of PCA using kernel methods.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/nMDS-class.Rd
+++ b/man/nMDS-class.Rd
@@ -17,7 +17,7 @@ A non-linear extension of MDS using monotonic regression
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 

--- a/man/tSNE-class.Rd
+++ b/man/tSNE-class.Rd
@@ -20,7 +20,7 @@ structures in low dimensions.
 \item{\code{fun}}{A function that does the embedding and returns a
 dimRedResult object.}
 
-\item{\code{stdpars}}{The standard parameters for the funciton.}
+\item{\code{stdpars}}{The standard parameters for the function.}
 }}
 \section{General usage}{
 


### PR DESCRIPTION
```r
> dat <- loadDataSet("3D S Curve")
> kpca <- kPCA()
> emb <- kpca@fun(dat, kpca@stdpars)
> dim(emb@apply(dat)@data)
[1] 2000   17
> 
> emb@pars
$kernel
[1] "rbfdot"

$kpar
$kpar$sigma
[1] 0.1


$ndim
[1] 2

> sessionInfo()
R version 3.3.2 (2016-10-31)
Platform: x86_64-apple-darwin13.4.0 (64-bit)
Running under: macOS Sierra 10.12.3

locale:
[1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] dimRed_0.0.3   DRR_0.0.2      CVST_0.2-1     Matrix_1.2-7.1 kernlab_0.9-25

loaded via a namespace (and not attached):
[1] tools_3.3.2     grid_3.3.2      lattice_0.20-34
```